### PR TITLE
Remove duplicate configuration settings from tsconfig

### DIFF
--- a/tsconfig.json
+++ b/tsconfig.json
@@ -7,10 +7,8 @@
         "noImplicitThis": true,
         "noImplicitReturns": true,
         "noUnusedLocals": true,
-        "noImplicitReturns": true,
         "strictNullChecks": true,
         "strict": true,
-        "alwaysStrict": true,
         "sourceMap": false,
         "outDir": "lib"
     }


### PR DESCRIPTION
Correcting errors reported in Visual Studio Code; linting did not care for the duplicate definitions.

Ensured that both definitions had the same values; config still works the same way.