### PR TITLE
Fix Coveralls complaining about Parallel Builds

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -28,6 +28,7 @@ jobs:
     - run: npm run cover
 
     - name: Coveralls
-      uses: coverallsapp/github-action@master
+      if: matrix.node-version == '20.x'
+      uses: coverallsapp/github-action@v1
       with:
         github-token: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
I'm just going to use an `if` to only make it run once - this is kind of a hack but simpler to manage than their suggested fix

https://docs.coveralls.io/parallel-builds