### PR TITLE
Potential fix for code scanning alert no. 1: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -3,6 +3,10 @@
 
 name: Node.js CI
 
+permissions:
+  contents: read
+  statuses: write
+
 on: [ push, pull_request ]
 
 jobs:


### PR DESCRIPTION
Potential fix for [https://github.com/donatj/CsvToMarkdownTable/security/code-scanning/1](https://github.com/donatj/CsvToMarkdownTable/security/code-scanning/1)

To fix the issue, we will add a `permissions` block at the root of the workflow file. This block will specify the minimal permissions required for the workflow to function correctly. Based on the tasks in the workflow, the following permissions are needed:
- `contents: read` for accessing repository contents.
- `statuses: write` for updating commit statuses (e.g., test results).
- `pull-requests: write` for interacting with pull requests (if applicable).

The `permissions` block will be added at the root level, applying to all jobs in the workflow.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
